### PR TITLE
Adds chmod to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ In addition, it is common to use [wgsim](https://github.com/lh3/wgsim) to simula
 ~~~~~~~~~~~~~~~~~~
 git clone git://github.com/GregoryFaust/SVsim.git
 cp SVsim/SVsim /usr/local/bin/
+chmod 755 /usr/local/bin/SVsim
 ~~~~~~~~~~~~~~~~~~
 
 ##Usage


### PR DESCRIPTION
In our experience, after cloning the repository and copying SVsim/SVsim to /usr/local/bin, we had to change permissions on the file to 755 (grant execute) in order to run SVsim at the command line without receiving a "Permissions Denied" error.